### PR TITLE
feat: support for excalidraw frames

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,8 +64,6 @@ jobs:
       # TODO: add build step for js code
       - name: Build package
         run: poetry build
-      - name: install package
-        run: pip install dist/mkdocs_excalidraw-*.whl
       - name: 🖼️ Build docs
         run: poetry run mkdocs gh-deploy --force
       - name: 📦 Publish package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dependencies = [
     "beautifulsoup4 (>=4.13.5,<5.0.0)"
 ]
 
+[tool.poetry]
+include = [
+    { path = "mkdocs_excalidraw/assets/excalidraw-renderer.bundle.js", format = ["sdist", "wheel"] }
+]
+
+
 [project.urls]
 Homepage = "https://github.com/qdeli187/mkdocs-excalidraw"
 Documentation = "https://qdeli187.github.io/mkdocs-excalidraw/"


### PR DESCRIPTION
In the last released we added the js bundle to gitignore, while it is not a bad idea , a unexpected side effect of this was that the bundle was not picked up by poetry
this pr adds explicitly the bundle to the build using the "include" directive of pyproject.toml
Also removed a step in the ci as it did not change a thing (as last build was a shitshow and the docs were fine)

closes #46 